### PR TITLE
Add hideSubAnchor config to hide the subAnchor index from the user

### DIFF
--- a/src/docsify-footnote.js
+++ b/src/docsify-footnote.js
@@ -41,9 +41,10 @@
                             const subAnchorIconList = [];
                             refMatchList.forEach(function(e1, j) {
                                 const subAnchor = j > 0 ? '-'+j : '';
+                                const displayIndex = $props.hideSubAnchor ? i : i+subAnchor;
                                 markdown = markdown.replace(
                                     noteMap[0],
-                                    `<sup class="footnote-symbol" id="ft-${i+subAnchor}">[\[${i+subAnchor}\]](#ftref-${i+subAnchor})</sup>`
+                                    `<sup class="footnote-symbol" id="ft-${i+subAnchor}">[\[${displayIndex}\]](#ftref-${i+subAnchor})</sup>`
                                 );
 
                                 subAnchorIconList.push(`<stronge id="ftref-${i+subAnchor}">[↩︎](#ft-${i+subAnchor})</stronge>`)
@@ -74,5 +75,8 @@
 
     // Add plugin to docsify's plugin array
     $docsify = $docsify || {};
+
+    $props = $docsify.docsifyFootnote || {};
+
     $docsify.plugins = [].concat($docsify.plugins || [], footnotePlugin);
 })();


### PR DESCRIPTION
Allows the user to set a config in the index.html file to hide the subAnchor.

All refs and ids were left alone, so links will still work regardless, and the default experience is still as it is today so nothing will change unexpectedly.

```html
<script>
    window.$docsify = {
        docsifyFootnote: {
            hideSubAnchor: true //Set to true to hide the subAnchor
        }
    }
</script>
```

## Examples
All examples use this markdown
```markdown
test[^1]

test[^1]

[^1]: Test File
```

### hideSubAnchor set to false (default)
![image](https://github.com/user-attachments/assets/9f8e51ea-0ba2-4ae7-b2b1-8a993412c349)

### hideSubAnchor set to true
![image](https://github.com/user-attachments/assets/33e10333-2b02-43fe-9e9d-27bd08949045)
